### PR TITLE
Disabled csharp compiler warnings.

### DIFF
--- a/src/Mapbox.IO.Compression.Shared/DeflateStreamAsyncResult.cs
+++ b/src/Mapbox.IO.Compression.Shared/DeflateStreamAsyncResult.cs
@@ -12,7 +12,9 @@ namespace Mapbox.IO.Compression {
         public bool isWrite;
 #pragma warning restore 0414
 
+#pragma warning disable 0414
         private object m_AsyncObject;               // Caller's async object.
+#pragma warning restore 0414
         private object m_AsyncState;                // Caller's state object.
         private AsyncCallback m_AsyncCallback;      // Caller's callback method.
 

--- a/src/Mapbox.IO.Compression.Shared/HuffmanTree.cs
+++ b/src/Mapbox.IO.Compression.Shared/HuffmanTree.cs
@@ -30,7 +30,9 @@ namespace Mapbox.IO.Compression
         short[]      right;
         byte[]       codeLengthArray;
 #if DEBUG
+#pragma warning disable 0414
         uint[]       codeArrayDebug;
+#pragma warning restore 0414
 #endif
 
         int tableMask;         


### PR DESCRIPTION
Added `#pragma warning disable` directives for warnings that would show up in Unity.